### PR TITLE
Add moment to externals in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,5 +33,8 @@ module.exports = {
   plugins: [
     // english locale is included, exclude the rest
     new webpack.IgnorePlugin(/locale/, /moment$/)
-  ]
+  ],
+  externals: {
+    "moment": "moment"
+  }
 };


### PR DESCRIPTION
Use moment as external library by default. This will allow to avoid duplication for those users who already use moment in their application. See externals option in [webpack wiki](https://webpack.github.io/docs/library-and-externals.html)