### PR TITLE
Babel does not babelify libraries on windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
     loaders: [
       {
         // need to babelify joi, isemail, hoek, and topo's lib
-        test: /\/node_modules\/(joi\/lib\/|isemail\/lib\/|hoek\/lib\/|topo\/lib\/)/,
+        test: /[\\\/]node_modules[\\\/](joi[\\\/]lib[\\\/]|isemail[\\\/]lib[\\\/]|hoek[\\\/]lib[\\\/]|topo[\\\/]lib[\\\/])/,
         loader: 'babel'
       },
       {


### PR DESCRIPTION
To fix this, the regex for the babel loader has been adjusted