### PR TITLE
update webpack node configs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,8 @@ module.exports = {
     ]
   },
   node: {
-    global: false,
+    global: true,
+    Buffer: 'mock',
     crypto: 'empty',
     net: 'empty',
     dns: 'empty'


### PR DESCRIPTION

It sets `global` polyfill and `Buffer` mock to suppress joi error on browser.
fixes #19 

ref: https://webpack.js.org/configuration/node/
